### PR TITLE
golangci-lint: remove unused settings, sort linters, and enable dupwords

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable:
     - bodyclose
+    - dupword # Checks for duplicate words in the source code
     - gofmt
     - goimports
     - ineffassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,17 @@
 linters:
   enable:
-    - staticcheck
-    - unconvert
+    - bodyclose
     - gofmt
     - goimports
-    - revive
     - ineffassign
-    - vet
-    - unused
     - misspell
-    - bodyclose
+    - revive
+    - staticcheck
+    - unconvert
+    - unused
+    - vet
   disable:
     - errcheck
 
-linters-settings:
-  revive:
-    rules:
-      # TODO(thaJeztah): temporarily disabled the "unused-parameter" check.
-      # It produces many warnings, and some of those may need to be looked at.
-      - name: unused-parameter
-        disabled: true
-
 run:
   deadline: 2m
-  skip-dirs:
-    - vendor

--- a/normalize.go
+++ b/normalize.go
@@ -140,7 +140,7 @@ func splitDockerDomain(name string) (domain, remainder string) {
 }
 
 // familiarizeName returns a shortened version of the name familiar
-// to to the Docker UI. Familiar names have the default domain
+// to the Docker UI. Familiar names have the default domain
 // "docker.io" and "library/" repository prefix removed.
 // For example, "docker.io/library/redis" will have the familiar
 // name "redis" and "docker.io/dmcgowan/myapp" will be "dmcgowan/myapp".


### PR DESCRIPTION
Noticed in one of the forks that there was a dupwords issue 😂 