### PR TITLE
remove deprecated SplitHostname

### DIFF
--- a/normalize_test.go
+++ b/normalize_test.go
@@ -466,62 +466,62 @@ func TestNormalizedSplitHostname(t *testing.T) {
 	tests := []struct {
 		input  string
 		domain string
-		name   string
+		path   string
 	}{
 		{
 			input:  "test.com/foo",
 			domain: "test.com",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "test_com/foo",
 			domain: "docker.io",
-			name:   "test_com/foo",
+			path:   "test_com/foo",
 		},
 		{
 			input:  "docker/migrator",
 			domain: "docker.io",
-			name:   "docker/migrator",
+			path:   "docker/migrator",
 		},
 		{
 			input:  "test.com:8080/foo",
 			domain: "test.com:8080",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "test-com:8080/foo",
 			domain: "test-com:8080",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "foo",
 			domain: "docker.io",
-			name:   "library/foo",
+			path:   "library/foo",
 		},
 		{
 			input:  "xn--n3h.com/foo",
 			domain: "xn--n3h.com",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "xn--n3h.com:18080/foo",
 			domain: "xn--n3h.com:18080",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "docker.io/foo",
 			domain: "docker.io",
-			name:   "library/foo",
+			path:   "library/foo",
 		},
 		{
 			input:  "docker.io/library/foo",
 			domain: "docker.io",
-			name:   "library/foo",
+			path:   "library/foo",
 		},
 		{
 			input:  "docker.io/library/foo/bar",
 			domain: "docker.io",
-			name:   "library/foo/bar",
+			path:   "library/foo/bar",
 		},
 	}
 	for _, tc := range tests {
@@ -532,12 +532,12 @@ func TestNormalizedSplitHostname(t *testing.T) {
 			if err != nil {
 				t.Errorf("error parsing name: %s", err)
 			}
-			domain, name := SplitHostname(named) //nolint:staticcheck // Ignore SA1019: SplitHostname is deprecated.
-			if domain != tc.domain {
+
+			if domain := Domain(named); domain != tc.domain {
 				t.Errorf("unexpected domain: got %q, expected %q", domain, tc.domain)
 			}
-			if name != tc.name {
-				t.Errorf("unexpected name: got %q, expected %q", name, tc.name)
+			if path := Path(named); path != tc.path {
+				t.Errorf("unexpected name: got %q, expected %q", path, tc.path)
 			}
 		})
 	}

--- a/reference.go
+++ b/reference.go
@@ -165,25 +165,15 @@ func Path(named Named) (name string) {
 	return path
 }
 
+// splitDomain splits a named reference into a hostname and path string.
+// If no valid hostname is found, the hostname is empty and the full value
+// is returned as name
 func splitDomain(name string) (string, string) {
 	match := anchoredNameRegexp.FindStringSubmatch(name)
 	if len(match) != 3 {
 		return "", name
 	}
 	return match[1], match[2]
-}
-
-// SplitHostname splits a named reference into a
-// hostname and name string. If no valid hostname is
-// found, the hostname is empty and the full value
-// is returned as name
-//
-// Deprecated: Use [Domain] or [Path].
-func SplitHostname(named Named) (string, string) {
-	if r, ok := named.(namedRepository); ok {
-		return r.Domain(), r.Path()
-	}
-	return splitDomain(named.Name())
 }
 
 // Parse parses s and returns a syntactically valid Reference.

--- a/reference_test.go
+++ b/reference_test.go
@@ -291,8 +291,7 @@ func TestReferenceParse(t *testing.T) {
 				if named.Name() != tc.repository {
 					t.Errorf("unexpected repository: got %q, expected %q", named.Name(), tc.repository)
 				}
-				domain, _ := SplitHostname(named)
-				if domain != tc.domain {
+				if domain := Domain(named); domain != tc.domain {
 					t.Errorf("unexpected domain: got %q, expected %q", domain, tc.domain)
 				}
 			} else if tc.repository != "" || tc.domain != "" {
@@ -373,42 +372,42 @@ func TestWithNameFailure(t *testing.T) {
 	}
 }
 
-func TestSplitHostname(t *testing.T) {
+func TestDomainAndPath(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		input  string
 		domain string
-		name   string
+		path   string
 	}{
 		{
 			input:  "test.com/foo",
 			domain: "test.com",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "test_com/foo",
 			domain: "",
-			name:   "test_com/foo",
+			path:   "test_com/foo",
 		},
 		{
 			input:  "test:8080/foo",
 			domain: "test:8080",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "test.com:8080/foo",
 			domain: "test.com:8080",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "test-com:8080/foo",
 			domain: "test-com:8080",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "xn--n3h.com:18080/foo",
 			domain: "xn--n3h.com:18080",
-			name:   "foo",
+			path:   "foo",
 		},
 	}
 	for _, tc := range tests {
@@ -419,12 +418,11 @@ func TestSplitHostname(t *testing.T) {
 			if err != nil {
 				t.Errorf("error parsing name: %s", err)
 			}
-			domain, name := SplitHostname(named)
-			if domain != tc.domain {
+			if domain := Domain(named); domain != tc.domain {
 				t.Errorf("unexpected domain: got %q, expected %q", domain, tc.domain)
 			}
-			if name != tc.name {
-				t.Errorf("unexpected name: got %q, expected %q", name, tc.name)
+			if path := Path(named); path != tc.path {
+				t.Errorf("unexpected name: got %q, expected %q", path, tc.path)
 			}
 		})
 	}
@@ -681,18 +679,18 @@ func TestParseNamed(t *testing.T) {
 	tests := []struct {
 		input  string
 		domain string
-		name   string
+		path   string
 		err    error
 	}{
 		{
 			input:  "test.com/foo",
 			domain: "test.com",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input:  "test:8080/foo",
 			domain: "test:8080",
-			name:   "foo",
+			path:   "foo",
 		},
 		{
 			input: "test_com/foo",
@@ -713,7 +711,7 @@ func TestParseNamed(t *testing.T) {
 		{
 			input:  "docker.io/library/foo",
 			domain: "docker.io",
-			name:   "library/foo",
+			path:   "library/foo",
 		},
 		// Ambiguous case, parser will add "library/" to foo
 		{
@@ -739,12 +737,11 @@ func TestParseNamed(t *testing.T) {
 				return
 			}
 
-			domain, name := SplitHostname(named)
-			if domain != tc.domain {
+			if domain := Domain(named); domain != tc.domain {
 				t.Errorf("unexpected domain: got %q, expected %q", domain, tc.domain)
 			}
-			if name != tc.name {
-				t.Errorf("unexpected name: got %q, expected %q", name, tc.name)
+			if path := Path(named); path != tc.path {
+				t.Errorf("unexpected name: got %q, expected %q", path, tc.path)
 			}
 		})
 	}


### PR DESCRIPTION
It was deprecated since distribution [v2.7.0-rc.0][1]

[1]: https://github.com/distribution/distribution/commit/9a43b8f6961d975f5d29587b3b89972bf18ea8dc