### PR TITLE
refactor splitDockerDomain to include more documentation

### DIFF
--- a/normalize_test.go
+++ b/normalize_test.go
@@ -13,6 +13,10 @@ func TestValidateReferenceName(t *testing.T) {
 		"docker/docker",
 		"library/debian",
 		"debian",
+		"localhost/library/debian",
+		"localhost/debian",
+		"LOCALDOMAIN/library/debian",
+		"LOCALDOMAIN/debian",
 		"docker.io/docker/docker",
 		"docker.io/library/debian",
 		"docker.io/debian",
@@ -147,6 +151,34 @@ func TestParseRepositoryInfo(t *testing.T) {
 	}
 
 	tests := []tcase{
+		{
+			RemoteName:    "fooo",
+			FamiliarName:  "localhost/fooo",
+			FullName:      "localhost/fooo",
+			AmbiguousName: "localhost/fooo",
+			Domain:        "localhost",
+		},
+		{
+			RemoteName:    "fooo/bar",
+			FamiliarName:  "localhost/fooo/bar",
+			FullName:      "localhost/fooo/bar",
+			AmbiguousName: "localhost/fooo/bar",
+			Domain:        "localhost",
+		},
+		{
+			RemoteName:    "fooo",
+			FamiliarName:  "LOCALDOMAIN/fooo",
+			FullName:      "LOCALDOMAIN/fooo",
+			AmbiguousName: "LOCALDOMAIN/fooo",
+			Domain:        "LOCALDOMAIN",
+		},
+		{
+			RemoteName:    "fooo/bar",
+			FamiliarName:  "LOCALDOMAIN/fooo/bar",
+			FullName:      "LOCALDOMAIN/fooo/bar",
+			AmbiguousName: "LOCALDOMAIN/fooo/bar",
+			Domain:        "LOCALDOMAIN",
+		},
 		{
 			RemoteName:    "fooo/bar",
 			FamiliarName:  "fooo/bar",


### PR DESCRIPTION
- relates to https://github.com/kubernetes/kubernetes/pull/120316#discussion_r1311815230
- relates to https://github.com/moby/moby/pull/46378

The splitDockerDomain attempts to determine whether the given name contains a domain, or should be used as a "remote-name". The logic used in doing so is based on (legacy) conventions, which have not always been properly documented.

The logic used in this function was also optimized for "brevity", but not easy to ready, due to the combination of multiple boolean conditions combined on a single line, and some "double negatives".

More documentation may still be needed, but let's start with documenting the logic used in this function;

- Use `strings.Cut()` instead of  `strings.IndexRune()`, which allows us to use descriptive variable names, and prevents use of the magic `-1` value.
- Split the conditions into a switch, so that each of them can be documented separately. While this makes the  code more verbose (and introduces some duplication), it should not impact performance, as only one condition would ever be met (performance may even be better, as the old code combined multiple conditions with `&&`).
- Introduce a fast-path for single-element ("familiar") names. These names can be canonicalized early, without doing further handling.

While working on the code, I also discovered an existing bug (or omission) where the code would not handle bare _domain names_. Ironically, the TestParseDockerRef test has a test-case name "hostname only", but which does not cover that case. THat test-case was transferred from containerd/cri, and does not describe this scenario (possibly was left as a "further exercise"); https://github.com/containerd/cri/commit/25fdf726923b607d0155550c5e85a911bb04bad1

Let keep it as a further exercise, but add a "TODO" to remind us doing so.