### PR TITLE
remove internal uses of ReferenceRegexp

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -232,9 +232,9 @@ func Parse(s string) (Reference, error) {
 		return nil, ErrNameEmpty
 	}
 
-	matches := ReferenceRegexp.FindStringSubmatch(s)
+	matches := referenceRegexp.FindStringSubmatch(s)
 	if matches == nil {
-		if sl := strings.ToLower(s); sl != s && ReferenceRegexp.FindStringSubmatch(sl) != nil {
+		if sl := strings.ToLower(s); sl != s && referenceRegexp.FindStringSubmatch(sl) != nil {
 			// Succeeds when lower-casing, so input contains an invalid repository name.
 			return nil, ErrNameContainsUppercase
 		}

--- a/regexp.go
+++ b/regexp.go
@@ -31,7 +31,7 @@ var NameRegexp = regexp.MustCompile(namePat)
 // ReferenceRegexp is the full supported format of a reference. The regexp
 // is anchored and has capturing groups for name, tag, and digest
 // components.
-var ReferenceRegexp = regexp.MustCompile(referencePat)
+var ReferenceRegexp = referenceRegexp
 
 // TagRegexp matches valid tag names. From [docker/docker:graph/tags.go].
 //
@@ -109,6 +109,11 @@ const (
 )
 
 var (
+	// referenceRegexp is the full supported format of a reference. The regexp
+	// is anchored and has capturing groups for name, tag, and digest
+	// components.
+	referenceRegexp = regexp.MustCompile(referencePat)
+
 	// anchoredTagRegexp matches valid tag names, anchored at the start and
 	// end of the matched string.
 	anchoredTagRegexp = regexp.MustCompile(anchored(tag))
@@ -131,7 +136,8 @@ var (
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
-	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domainAndPort), `/`), capture(remoteName)))
+	anchoredNameRegexp = regexp.MustCompile(anchoredNamePat)
+	anchoredNamePat    = anchored(optional(capture(domainAndPort), `/`), capture(remoteName))
 
 	referencePat = anchored(capture(namePat), optional(`:`, capture(tag)), optional(`@`, capture(digestPat)))
 

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -179,9 +179,8 @@ func TestDomainRegexp(t *testing.T) {
 
 func TestFullNameRegexp(t *testing.T) {
 	t.Parallel()
-	if anchoredNameRegexp.NumSubexp() != 2 {
-		t.Fatalf("anchored name regexp should have two submatches: %v, %v != 2",
-			anchoredNameRegexp, anchoredNameRegexp.NumSubexp())
+	if n := anchoredNameRegexp.NumSubexp(); n != 2 {
+		t.Fatalf("anchored name regexp should have two submatches: %v, %v != 2", anchoredNamePat, n)
 	}
 
 	tests := []regexpMatch{
@@ -479,9 +478,8 @@ func TestFullNameRegexp(t *testing.T) {
 
 func TestReferenceRegexp(t *testing.T) {
 	t.Parallel()
-	if ReferenceRegexp.NumSubexp() != 3 {
-		t.Fatalf("anchored name regexp should have three submatches: %v, %v != 3",
-			ReferenceRegexp, ReferenceRegexp.NumSubexp())
+	if n := referenceRegexp.NumSubexp(); n != 3 {
+		t.Fatalf("anchored name regexp should have three submatches: %v, %v != 3", referencePat, n)
 	}
 
 	tests := []regexpMatch{
@@ -547,7 +545,7 @@ func TestReferenceRegexp(t *testing.T) {
 		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
-			checkRegexp(t, ReferenceRegexp, tc)
+			checkRegexp(t, referenceRegexp, tc)
 		})
 	}
 }


### PR DESCRIPTION
- [x] stacked on https://github.com/distribution/reference/pull/26

### remove internal uses of ReferenceRegexp

Split into a non-exported and exported regex, and use the non-exported regex internally.
